### PR TITLE
fix: resolve CDB relative paths against entry directory per spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-cpp-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-cpp-server"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "MIT"
 description = "A high-performance Model Context Protocol (MCP) server for C++ code analysis using clangd LSP integration"

--- a/src/project/compilation_database.rs
+++ b/src/project/compilation_database.rs
@@ -78,6 +78,12 @@ impl CompilationDatabase {
         }
     }
 
+    /// Create a compilation database from entries with a custom path for testing
+    #[cfg(test)]
+    pub fn from_entries_with_path(path: PathBuf, entries: Vec<Entry>) -> Self {
+        Self { path, entries }
+    }
+
     /// Get all compilation database entries
     #[allow(dead_code)]
     pub fn entries(&self) -> &[Entry] {
@@ -91,15 +97,14 @@ impl CompilationDatabase {
 
     /// Get all unique source files with canonicalized paths
     ///
-    /// This method resolves relative paths against the compilation database directory
-    /// and canonicalizes them to absolute paths. This ensures consistent path handling
-    /// between CMake (which uses absolute paths) and Meson (which uses relative paths).
+    /// This method resolves relative paths against each entry's `directory` field
+    /// per the compile_commands.json spec, then canonicalizes them to absolute paths.
     pub fn canonical_source_files(&self) -> Result<Vec<PathBuf>, CompilationDatabaseError> {
         let mut canonical_files = Vec::new();
         let mut seen_files = std::collections::HashSet::new();
 
         for entry in &self.entries {
-            let canonical_path = self.canonicalize_entry_path(&entry.file)?;
+            let canonical_path = self.canonicalize_entry_path(&entry.file, &entry.directory)?;
             if seen_files.insert(canonical_path.clone()) {
                 canonical_files.push(canonical_path);
             }
@@ -119,7 +124,7 @@ impl CompilationDatabase {
 
         for entry in &self.entries {
             let original_path = entry.file.clone();
-            let canonical_path = self.canonicalize_entry_path(&entry.file)?;
+            let canonical_path = self.canonicalize_entry_path(&entry.file, &entry.directory)?;
 
             original_to_canonical.insert(original_path.clone(), canonical_path.clone());
             canonical_to_original.insert(canonical_path, original_path);
@@ -128,44 +133,244 @@ impl CompilationDatabase {
         Ok((original_to_canonical, canonical_to_original))
     }
 
-    /// Canonicalize a single entry path using the same logic for all paths
+    /// Canonicalize a single entry path using the entry's directory field
     ///
-    /// This is the single source of truth for path canonicalization in the system.
-    /// It handles both CMake's absolute paths and Meson's relative paths consistently.
+    /// Per the compile_commands.json spec, relative `file` paths must be resolved
+    /// against the entry's `directory` field (the compilation working directory),
+    /// NOT against the location of compile_commands.json itself.
+    /// Falls back to compile_commands.json parent directory when entry directory is empty.
     fn canonicalize_entry_path(
         &self,
         entry_path: &Path,
+        entry_directory: &Path,
     ) -> Result<PathBuf, CompilationDatabaseError> {
-        let compilation_db_dir = self.path.parent().unwrap_or_else(|| Path::new("."));
+        // Per spec: resolve relative file paths against the entry's `directory` field.
+        // Fall back to compile_commands.json parent when entry directory is empty.
+        let base_dir = if entry_directory.as_os_str().is_empty() {
+            self.path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        } else {
+            entry_directory.to_path_buf()
+        };
 
-        // Resolve relative paths against compilation database directory
         let resolved_path = if entry_path.is_relative() {
-            compilation_db_dir.join(entry_path)
+            base_dir.join(entry_path)
         } else {
             entry_path.to_path_buf()
         };
 
-        // Attempt canonicalization, fall back to resolved path if it fails
-        // This handles cases where files don't exist yet (like in tests)
+        // Attempt canonicalization, fall back to logical normalization if it fails
+        // (canonicalize requires the path to exist on disk)
         match resolved_path.canonicalize() {
             Ok(canonical) => Ok(canonical),
-            Err(_) => {
-                // For non-existent files (tests, etc.), use the resolved path
-                Ok(resolved_path)
-            }
+            Err(_) => Ok(normalize_path(&resolved_path)),
         }
     }
 }
 
+/// Logically normalize a path by resolving `.` and `..` components without filesystem access.
+/// Unlike `canonicalize()`, this works on non-existent paths.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                if matches!(components.last(), Some(std::path::Component::Normal(_))) {
+                    components.pop();
+                } else {
+                    components.push(component);
+                }
+            }
+            std::path::Component::CurDir => {}
+            _ => {
+                components.push(component);
+            }
+        }
+    }
+    components.iter().collect()
+}
+
 /// Custom serialization that only outputs the path field
-///
-/// This ensures that when the CompilationDatabase is serialized (e.g., in JSON responses),
-/// only the path is included, not the potentially large entries array.
 impl Serialize for CompilationDatabase {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         self.path.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use json_compilation_db::Entry;
+    use std::path::PathBuf;
+
+    fn make_entry(directory: &str, file: &str) -> Entry {
+        Entry {
+            directory: PathBuf::from(directory),
+            file: PathBuf::from(file),
+            arguments: vec!["clang++".to_string(), file.to_string()],
+            output: None,
+        }
+    }
+
+    /// Normalize path to forward slashes for cross-platform assertion comparison
+    fn norm(path: &Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
+    }
+
+    #[test]
+    fn test_relative_path_resolved_against_entry_directory() {
+        // Bug scenario: CDB is in /output/build/, but entry.directory points to /src/project/
+        // Relative file path should resolve against /src/project/, NOT /output/build/
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/output/build/compile_commands.json"),
+            vec![make_entry("/src/project", "../../lib/engine/main.cpp")],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 1);
+
+        let resolved_str = norm(&files[0]);
+        assert!(
+            !resolved_str.contains("/output/"),
+            "Path should NOT resolve against CDB parent (/output/build): got {resolved_str}"
+        );
+        assert!(
+            resolved_str.contains("/lib/engine/main.cpp"),
+            "Path should contain the resolved file component: got {resolved_str}"
+        );
+    }
+
+    #[test]
+    fn test_absolute_path_ignores_directory() {
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/output/build/compile_commands.json"),
+            vec![make_entry("/src/project", "/absolute/path/to/file.cpp")],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 1);
+        let s = norm(&files[0]);
+        assert!(
+            s.contains("/absolute/path/to/file.cpp"),
+            "Absolute path should be preserved: got {s}"
+        );
+    }
+
+    #[test]
+    fn test_empty_directory_falls_back_to_cdb_parent() {
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/build/compile_commands.json"),
+            vec![make_entry("", "src/main.cpp")],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 1);
+        let s = norm(&files[0]);
+        assert!(
+            s.contains("/build/src/main.cpp"),
+            "Empty directory should fall back to CDB parent: got {s}"
+        );
+    }
+
+    #[test]
+    fn test_cmake_style_same_directory_still_works() {
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/project/build/compile_commands.json"),
+            vec![make_entry("/project/build", "../src/main.cpp")],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 1);
+        let s = norm(&files[0]);
+        // ../src/main.cpp from /project/build → /project/src/main.cpp
+        assert!(
+            s.contains("/project/") && s.ends_with("src/main.cpp"),
+            "CMake-style resolution should still work: got {s}"
+        );
+    }
+
+    #[test]
+    fn test_path_mappings_use_entry_directory() {
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/output/compile_commands.json"),
+            vec![make_entry("/src/project", "lib/utils.cpp")],
+        );
+
+        let (orig_to_canon, _canon_to_orig) = cdb.path_mappings().unwrap();
+        let original = PathBuf::from("lib/utils.cpp");
+        let canonical = orig_to_canon.get(&original).expect("mapping should exist");
+        let s = norm(canonical);
+
+        assert!(
+            !s.contains("/output/"),
+            "path_mappings should resolve against entry directory: got {s}"
+        );
+        assert!(
+            s.contains("/src/project/lib/utils.cpp"),
+            "path_mappings should contain correct resolved path: got {s}"
+        );
+    }
+
+    #[test]
+    fn test_multiple_entries_different_directories() {
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/output/compile_commands.json"),
+            vec![
+                make_entry("/project/moduleA", "src/a.cpp"),
+                make_entry("/project/moduleB", "src/b.cpp"),
+            ],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 2);
+
+        let paths: Vec<String> = files.iter().map(|p| norm(p)).collect();
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.contains("/project/moduleA/src/a.cpp")),
+            "Should resolve a.cpp against moduleA: got {:?}",
+            paths
+        );
+        assert!(
+            paths
+                .iter()
+                .any(|p| p.contains("/project/moduleB/src/b.cpp")),
+            "Should resolve b.cpp against moduleB: got {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn test_dagor_engine_scenario() {
+        // Real-world scenario from bug report: Dagor Engine
+        let cdb = CompilationDatabase::from_entries_with_path(
+            PathBuf::from("/output/_clangd/18.1.8/_daNetGame/windows/compile_commands.json"),
+            vec![make_entry(
+                "/dagor2/active_matter/prog",
+                "../../prog/engine/phys/joltPhysics.cpp",
+            )],
+        );
+
+        let files = cdb.canonical_source_files().unwrap();
+        assert_eq!(files.len(), 1);
+
+        let s = norm(&files[0]);
+        assert!(
+            !s.contains("_clangd"),
+            "Dagor: must NOT resolve against CDB parent: got {s}"
+        );
+        // ../../prog/engine/... from /dagor2/active_matter/prog
+        // → /dagor2/prog/engine/phys/joltPhysics.cpp
+        assert!(
+            s.contains("/dagor2/prog/engine/phys/joltPhysics.cpp")
+                || s.contains("dagor2/prog/engine/phys/joltPhysics.cpp"),
+            "Dagor: should resolve to source tree: got {s}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`compile_commands.json` relative `file` paths were resolved against the directory containing `compile_commands.json` instead of each entry's `directory` field, breaking all non-CMake build systems.

- **Root cause**: `canonicalize_entry_path()` ignored `entry.directory` and used CDB parent dir
- **Fix**: Added `entry_directory` parameter, resolve relative paths against it per [spec](https://clang.llvm.org/docs/JSONCompilationDatabase.html)
- **Bonus**: Added `normalize_path()` for logical `..`/`.` resolution without filesystem access (fixes 4 pre-existing test failures)
- **7 new tests** covering relative paths, absolute paths, empty directory fallback, CMake compatibility, and custom build system scenarios

## Test plan

- [x] `cargo clippy` — clean
- [x] `cargo test` — 241 pass, 1 pre-existing cmake env failure
- [x] E2E — MCP handshake + `search_symbols("Math")` finds symbol

🤖 Generated with [Claude Code](https://claude.com/claude-code)